### PR TITLE
Add note about namespaced context classes with example

### DIFF
--- a/guides/6.profiles.rst
+++ b/guides/6.profiles.rst
@@ -15,7 +15,21 @@ you want to autoload via ``behat.yml``:
     default:
         autoload:
             '': %paths.base%/app/features/bootstrap
-                
+
+If you wish to namespace your features (for example: to be PSR-1 complaint) you will need to add the namespace to the classes and also tell behat where to load them. Here ``contexts`` is an array of classes:
+
+.. code-block:: yaml
+
+
+    # behat.yml
+
+    default:
+        autoload:
+            '': %paths.base%/app/features/bootstrap
+        suites:
+            default:
+                contexts: [My\Application\Namespace\Bootstrap\FeatureContext]
+
 .. note::
 
     Using ``behat.yml`` to autoload will only allow for ``PSR-0``


### PR DESCRIPTION
For example this is an issue where somebody may wish to namespace their classes to become PSR-2 compliant, but once namespaces behat can no longer find the contexts without this configuration.
