### PR TITLE
Expand font stack

### DIFF
--- a/_themes/borg/static/css/borg.css
+++ b/_themes/borg/static/css/borg.css
@@ -1,5 +1,5 @@
 html {
-    font-family: "Helvetica Neue";
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-size: 62.5%;
 }
 


### PR DESCRIPTION
Because it looks ugly in Times New Roman on a Windows machine. :smiley:
