### PR TITLE
Added TableNode::getHash() to code sample

### DIFF
--- a/guides/1.gherkin.rst
+++ b/guides/1.gherkin.rst
@@ -454,6 +454,8 @@ usually as input to a Given or as expected output from a Then.
          */
         public function thePeopleExist(TableNode $table)
         {
+            $hash = $table->getHash();
+            
             foreach ($hash as $row) {
                 // $row['name'], $row['email'], $row['phone']
             }


### PR DESCRIPTION
The code sample for iterating through a TableNode hash was missing the part where the hash is extracted from the TableNode object.
