### PR TITLE
Fix reference to mink:symfony

### DIFF
--- a/cookbook/intercepting_the_redirections.rst
+++ b/cookbook/intercepting_the_redirections.rst
@@ -55,7 +55,7 @@ the features with this step to avoid misuses):
             if (!$driver instanceof GoutteDriver) {
                 throw new UnsupportedDriverActionException(
                     'You need to tag the scenario with '.
-                    '"@mink:goutte" or "@mink:symfony". '.
+                    '"@mink:goutte" or "@mink:symfony2". '.
                     'Intercepting the redirections is not '.
                     'supported by %s', $driver
                 );
@@ -72,7 +72,7 @@ the features with this step to avoid misuses):
 
     .. code-block:: gherkin
 
-        @mink:symfony
+        @mink:symfony2
         Scenario: I should receive an email
 
 Implementing Interception Steps Logic


### PR DESCRIPTION
The correct tag for the `Symfony2Extension` has been `@mink:symfony2` rather than `@mink:symfony` since https://github.com/Behat/Symfony2Extension/commit/ff6a1e590e421cabcb1f7afd99ad6b01c3b731b6
