### PR TITLE
Update 6.profiles.rst

### DIFF
--- a/guides/6.profiles.rst
+++ b/guides/6.profiles.rst
@@ -22,7 +22,7 @@ In this instance, scenarios tagged as @wip will be ignored unless the CLI comman
 
 .. code-block:: bash
 
-    /bin/behat --tags=wip
+    vendor/bin/behat --tags=wip
 
 Custom Autoloading
 ------------------


### PR DESCRIPTION
Missing vendor/ prefix.

This seems to be the only one in the PDF version.
