### PR TITLE
Fixed incorrect admin_features path in behat.yml example

### DIFF
--- a/guides/5.suites.rst
+++ b/guides/5.suites.rst
@@ -24,7 +24,7 @@ really powerful and ``behat.yml`` makes them that much more powerful:
                 filters:  { role: user }
                 contexts: [ UserContext ]
             admin_features:
-                paths:    [ %paths.base%/features/web ]
+                paths:    [ %paths.base%/features/admin ]
                 filters:  { role: admin }
                 contexts: [ AdminContext ]
 


### PR DESCRIPTION
admin_features path was referencing a web directory
 instead of an admin directory
