### PR TITLE
Clarify how to enable colorful output

### DIFF
--- a/guides/2.definitions.rst
+++ b/guides/2.definitions.rst
@@ -289,8 +289,9 @@ execution.
 
 .. tip::
 
-    Install ``php5-posix`` on Linux, Mac OS or other Unix system
-    to be able to see colorful Behat output.
+    Enable the "posix" PHP extension in order to see colorful Behat output.
+    Depending on your Linux, Mac OS or other Unix system it might be part
+    of the default PHP installation or a separate ``php5-posix`` package.
 
 Undefined Steps
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
The current documentation suggests to install the "php5-posix" package but this seems to be no very common among different distributions. As far as I could see through a Google search this is included in the default installation for recent PHP versions, except for a handful of distributions like OpenSUSE and FreeBSD.
