### PR TITLE
Update using_spin_functions.rst

### DIFF
--- a/cookbook/using_spin_functions.rst
+++ b/cookbook/using_spin_functions.rst
@@ -110,7 +110,7 @@ sit spinning forever. To resolve this, we can add a timeout.
                 // do nothing
             }
             
-            sleep(1);
+            $this->getSession()->wait(500); // miliseconds
         }
         
         $backtrace = debug_backtrace();


### PR DESCRIPTION
Use session wait to specify the wait time in miliseconds, because often a whole second is too long and makes the tests much slower if you have many things that need the spin. Even in cases where one second is not enough, waiting less between retries should save time, as long as the actual process being repeated is not very expensive. I guess ideally the wait would be another argument to spin.
