### PR TITLE
Use std string instead STDOUT

### DIFF
--- a/guides/7.run.rst
+++ b/guides/7.run.rst
@@ -53,7 +53,7 @@ them to use different ones - specify them with ``--out``:
 
 .. code-block:: bash
 
-    $ behat -f pretty -o ~/pretty.out -f progress -o STDOUT -f junit -o xml
+    $ behat -f pretty -o ~/pretty.out -f progress -o std -f junit -o xml
 
 In this case, output of pretty formatter will be written to ``~/pretty.out`` file, output of junit
 formatter will be written to ``xml`` folder and progress formatter will just print to console.


### PR DESCRIPTION
If use string `STDOUT` in output option, Behat create a file. But if you use `std` string the output redirect correctly to the `stdout`
