### PR TITLE
Fix typos

### DIFF
--- a/guides/3.hooks.rst
+++ b/guides/3.hooks.rst
@@ -164,7 +164,7 @@ Feature Hooks
 -------------
 
 Same as suite hooks, feature hooks are ran outside of the scenario context.
-So same as suite hooks, your feature hooks should be defined as static methods
+So same as suite hooks, your feature hooks must be defined as static methods
 inside your context:
 
 .. code-block:: php


### PR DESCRIPTION
Use more definitive language. `should` makes it sound like it could be a non-static method, but static is preferred.
