### PR TITLE
Change path to the Behat executable file

### DIFF
--- a/cookbooks/1.symfony2_integration.rst
+++ b/cookbooks/1.symfony2_integration.rst
@@ -42,7 +42,7 @@ In order to verify Behat initialisation you can just run following command:
 
 .. code-block:: bash
 
-    $ bin/behat
+    $ vendor/bin/behat
 
 .. tip::
 


### PR DESCRIPTION
According to the latest changes for Symfony 3.x all bin files are in the `vendor/bin` folder
