### PR TITLE
Fix wrong bin directory for Symfony2 applications

### DIFF
--- a/cookbooks/integrating_symfony2_with_behat.rst
+++ b/cookbooks/integrating_symfony2_with_behat.rst
@@ -42,7 +42,7 @@ In order to verify Behat initialisation you can just run following command:
 
 .. code-block:: bash
 
-    $ vendor/bin/behat
+    $ bin/behat
 
 .. tip::
 

--- a/cookbooks/integrating_symfony2_with_behat.rst
+++ b/cookbooks/integrating_symfony2_with_behat.rst
@@ -42,7 +42,7 @@ In order to verify Behat initialisation you can just run following command:
 
 .. code-block:: bash
 
-    $ bin/behat
+    $ vendor/bin/behat
 
 .. tip::
 

--- a/cookbooks/integrating_symfony2_with_behat.rst
+++ b/cookbooks/integrating_symfony2_with_behat.rst
@@ -46,6 +46,16 @@ In order to verify Behat initialisation you can just run following command:
 
 .. tip::
 
+    If the command above doesn't work, you may need to run ``bin/behat`` instead.
+
+Next, let's initialize Behat:
+
+.. code-block:: bash
+
+    $ vendor/bin/behat --init
+
+.. tip::
+
     If you don't feel familiar with Behat enough please read :doc:`/quick_start`
     first.
 


### PR DESCRIPTION
Because Symfony has set `config.bin-dir = "bin"` in `composer.json`, binaries are installed to `bin` rather than `vendor/bin`.

I did the following:

1. Installed Symfony 2.8 using the Symfony installer: `symfony new behat-symfony-tutorial 2.8`.
2. Installed Behat: `cd behat-symfony-tutorial && composer require --dev behat/behat
3. Tried running Behat: `vendor/bin/behat`

## Expected result
```
[Behat\Behat\Context\Exception\ContextNotFoundException]       
  `FeatureContext` context class not found and can not be used.
```

## Actual result
`zsh: no such file or directory: vendor/bin/behat`

To fix this, I used `bin/behat` instead.

I think the documentation should be updated to reflect Symfony 2.8 standard behavior.