### PR TITLE
docs(cookbooks): adding creating a behat extension

### DIFF
--- a/cookbooks.rst
+++ b/cookbooks.rst
@@ -6,3 +6,4 @@ Cookbooks
 
    cookbooks/integrating_symfony2_with_behat
    cookbooks/accessing_contexts_from_each_other
+   cookbooks/creating_a_behat_extension

--- a/cookbooks.rst
+++ b/cookbooks.rst
@@ -6,4 +6,4 @@ Cookbooks
 
    cookbooks/integrating_symfony2_with_behat
    cookbooks/accessing_contexts_from_each_other
-   cookbooks/creating_a_behat_extension
+   cookbooks/creating_a_context_configuration_extension

--- a/cookbooks/creating_a_behat_extension.rst
+++ b/cookbooks/creating_a_behat_extension.rst
@@ -26,7 +26,7 @@ The ``LogsExtension`` will provide a ``LogsContext`` that hooks into scenarios t
 Directory structure:
 
 .. code-block::
-  
+
   src/
       Context/
           LogsContext.php   # This is where we'll implement our logging logic
@@ -37,13 +37,13 @@ The code for ``LogsContext.php``:
 .. code-block:: php
 
   <?php
-  
-  namespace Behat\LogsExtension\Context;
-  
+
+  namespace LogsExtension\Context;
+
   use Behat\Behat\Context\Context;
   use Behat\Behat\Hook\Scope\BeforeScenarioScope;
   use Behat\Behat\Hook\Scope\AfterScenarioScope;
-  
+
   class LogsContext implements Context
   {
       /** @BeforeScenario */
@@ -59,14 +59,14 @@ The code for ``LogsContext.php``:
               FILE_APPEND
           );
       }
-  
+
       /** @AfterScenario */
       public function after(AfterScenarioScope $scope)
       {
           if (/* enable config */ === false) {
               return;
           }
-  
+
           file_put_contents(
               /* filepath */,
               'END: ' . $scope->getScenario()->getTitle() . ' - ' . time() . PHP_EOL,
@@ -84,7 +84,7 @@ This will serve as the entry point for our logging functionality.
 Directory structure:
 
 .. code-block::
-  
+
   src/
       Context/
           LogsContext.php
@@ -99,23 +99,23 @@ The ``getConfigKey`` method is used to identify our extension in the configurati
 The code for ``LogsExtension.php``:
 
 .. code-block:: php
-  
+
   <?php
-  
-  namespace Behat\LogsExtension\ServiceContainer;
-  
+
+  namespace LogsExtension\ServiceContainer;
+
   use Behat\Testwork\ServiceContainer\Extension;
   use Behat\Testwork\ServiceContainer\ExtensionManager;
   use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
   use Symfony\Component\DependencyInjection\ContainerBuilder;
-  
+
   class LogsExtension implements Extension
   {
       public function getConfigKey()
       {
           return 'logs_extension';
       }
-  
+
       public function initialize(ExtensionManager $extensionManager)
       {
           // Empty for our case, but useful to hook into other extensions' configurations
@@ -126,12 +126,12 @@ The code for ``LogsExtension.php``:
           $builder
               ->addDefaultsIfNotSet()
               ->children()
-                  ->scalarNode('enable')->defaultFalse()->end()
+                  ->booleanNode('enable')->defaultFalse()->end()
                   ->scalarNode('filepath')->defaultValue('behat.log')->end()
               ->end()
           ;
       }
-  
+
       public function load(ContainerBuilder $container, array $config)
       {
           // ... we'll load our configuration here
@@ -144,7 +144,7 @@ The code for ``LogsExtension.php``:
   }
 
 .. note::
-  
+
   The ``initialize`` and ``process`` methods are empty in our case but are useful when you need to interact with other extensions or process the container after it has been compiled.
 
 Initializing the Context
@@ -169,7 +169,7 @@ The code for ``LogsInitializer.php``:
 
   <?php
 
-  namespace Behat\LogsExtension\Context\Initializer;
+  namespace LogsExtension\Context\Initializer;
 
   use Behat\LogsExtension\Context\LogsContext;
   use Behat\Behat\Context\Context;
@@ -179,19 +179,19 @@ The code for ``LogsInitializer.php``:
   {
       private string $filepath;
       private bool $enable;
-  
+
       public function __construct(string $filepath, bool $enable)
       {
           $this->filepath = $filepath;
           $this->enable = $enable;
       }
-  
+
       public function initializeContext(Context $context)
       {
-          /* 
+          /*
            * At the start of every scenario, behat will create a new instance of every `Context`
            * registered in your project. It will then call this method with each new `Context` in
-           * turn. If you want to initialise multiple contexts, you can of course give them an 
+           * turn. If you want to initialise multiple contexts, you can of course give them an
            * interface and check for that here.
            */
           if (!$context instanceof LogsContext) {
@@ -216,7 +216,7 @@ We need to register the initializer definition within the Behat container throug
   class LogsExtension implements Extension
   {
       // ...
-  
+
       public function load(ContainerBuilder $container, array $config)
       {
           $definition = new Definition(LogsInitializer::class, [
@@ -235,18 +235,18 @@ To complete the extension, we must add methods to ``LogsContext`` to receive the
 .. code-block:: php
 
   // ...
-  
+
   class LogsContext implements Context
   {
       private bool $enable = false;
       private string $filepath;
-  
+
       public function initializeConfig(bool $enable, string $filepath)
       {
           $this->enable = $enable;
           $this->filepath = $filepath;
       }
-  
+
       /** @BeforeScenario */
       public function before(BeforeScenarioScope $scope)
       {
@@ -260,14 +260,14 @@ To complete the extension, we must add methods to ``LogsContext`` to receive the
               FILE_APPEND
           );
       }
-  
+
       /** @AfterScenario */
       public function after(AfterScenarioScope $scope)
       {
           if ($this->enable === false) {
               return;
           }
-  
+
           file_put_contents(
               $this->filepath,
               'END: ' . $scope->getScenario()->getTitle() . ' - ' . time() . PHP_EOL,

--- a/cookbooks/creating_a_behat_extension.rst
+++ b/cookbooks/creating_a_behat_extension.rst
@@ -1,0 +1,270 @@
+Creating a Behat extension
+==========================
+
+Extensions are particularly useful when configuration becomes a necessity.
+
+In this cookbook, we will create a simple extension named ``LogsExtension`` that logs scenario durations and cover:
+
+#. Setting up the context
+#. Creating the extension
+#. Initializing the context
+
+Setting Up the Context
+----------------------
+
+First, we need to create a context that will handle the logging.
+The ``LogsExtension`` will provide a ``LogsContext`` that hooks into scenarios to log their start and end times.
+
+Directory structure:
+
+.. code-block::
+  
+  src/
+      Context/
+          LogsContext.php   # This is where we'll implement our logging logic
+
+
+The code for ``LogsContext.php``:
+
+.. code-block:: php
+
+  <?php
+  
+  namespace Behat\LogsExtension\Context;
+  
+  use Behat\Behat\Context\Context;
+  use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+  use Behat\Behat\Hook\Scope\AfterScenarioScope;
+  
+  class LogsContext implements Context
+  {
+      /** @BeforeScenario */
+      public function before(BeforeScenarioScope $scope)
+      {
+          if (/* enable config */ === false) {
+              return;
+          }
+
+          file_put_contents(
+              /* filepath */,
+              'START: ' . $scope->getScenario()->getTitle() . ' - ' . time() . PHP_EOL,
+              FILE_APPEND
+          );
+      }
+  
+      /** @AfterScenario */
+      public function after(AfterScenarioScope $scope)
+      {
+          if (/* enable config */ === false) {
+              return;
+          }
+  
+          file_put_contents(
+              /* filepath */,
+              'END: ' . $scope->getScenario()->getTitle() . ' - ' . time() . PHP_EOL,
+              FILE_APPEND
+          );
+      }
+  }
+
+Creating the Extension
+----------------------
+
+Next, we need to create the extension itself.
+This will serve as the entry point for our logging functionality.
+
+Directory structure:
+
+.. code-block::
+  
+  src/
+      Context/
+          LogsContext.php
+      ServiceContainer/
+          LogsExtension.php   # This is where we'll define our extension
+
+To ensure Behat can find and load the ``LogsExtension.php`` file, it is important to place it within the `ServiceContainer` folder.
+While there might be alternatives, we will stick to the straightforward method.
+
+The ``getConfigKey`` method is used to identify our extension in the configuration, and the ``configure`` method is used to define the configuration tree.
+
+The code for `LogsExtension.php`:
+
+.. code-block:: php
+  
+  <?php
+  
+  namespace Behat\LogsExtension\ServiceContainer;
+  
+  use Behat\Testwork\ServiceContainer\Extension;
+  use Behat\Testwork\ServiceContainer\ExtensionManager;
+  use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+  use Symfony\Component\DependencyInjection\ContainerBuilder;
+  
+  class LogsExtension implements Extension
+  {
+      public function getConfigKey()
+      {
+          return 'logs_extension';
+      }
+  
+      public function initialize(ExtensionManager $extensionManager)
+      {
+          // Empty for our case, but useful to hook into other extensions' configurations
+      }
+
+      public function configure(ArrayNodeDefinition $builder)
+      {
+          $builder
+              ->addDefaultsIfNotSet()
+              ->children()
+                  ->scalarNode('enable')->defaultFalse()->end()
+                  ->scalarNode('filepath')->defaultValue('behat.log')->end()
+              ->end()
+          ;
+      }
+  
+      public function load(ContainerBuilder $container, array $config)
+      {
+          // ... we'll load our configuration here
+      }
+
+      public function process(ContainerBuilder $container)
+      {
+          // Empty for our case but needed for CompilerPassInterface
+      }
+  }
+
+.. note::
+  
+  The ``initialize`` and ``process`` methods are empty in our case but are useful when you need to interact with other extensions or process the container after it has been compiled.
+
+Initializing the Context
+------------------------
+
+To pass configuration values to our ``LogsContext``, we need to create an initializer.
+
+Directory structure:
+
+.. code-block::
+  src/
+      Context/
+          Initializer/
+              LogsInitializer.php   # This will handle context initialization
+          LogsContext.php
+      ServiceContainer/
+          LogsExtension.php
+
+The code for ``LogsInitializer.php``:
+
+.. code-block:: php  
+  <?php
+
+  namespace Behat\LogsExtension\Context\Initializer;
+
+  use Behat\LogsExtension\Context\LogsContext;
+  use Behat\Behat\Context\Context;
+  use Behat\Behat\Context\Initializer\ContextInitializer;
+
+  class LogsInitializer implements ContextInitializer
+  {
+      private string $filepath;
+      private bool $enable;
+  
+      public function __construct(string $filepath, bool $enable)
+      {
+          $this->filepath = $filepath;
+          $this->enable = $enable;
+      }
+  
+      public function initializeContext(Context $context)
+      {
+          if (!$context instanceof LogsContext) {
+              return;
+          }
+
+          $context->initializeConfig($this->enable, $this->filepath);
+      }
+  }
+
+We need to register the initializer definition within the Behat container through the ``LogsExtension``, ensuring it gets loaded:
+
+.. code-block:: php
+  <?php
+
+  // ...
+
+  use Symfony\Component\DependencyInjection\Definition;
+  use Behat\Behat\Context\ServiceContainer\ContextExtension;
+
+  class LogsExtension implements Extension
+  {
+      // ...
+  
+      public function load(ContainerBuilder $container, array $config)
+      {
+          $definition = new Definition(LogsInitializer::class, [
+              $config['filepath'],
+              $config['enable'],
+          ]);
+          $definition->addTag(ContextExtension::INITIALIZER_TAG);
+          $container->setDefinition('logs_extension.context_initializer', $definition);
+      }
+
+      // ...
+  }
+
+To complete the extension, we must add methods to ``LogsContext`` to receive the configuration values and use those in the hooks:
+
+.. code-block:: php
+
+  // ...
+  
+  class LogsContext implements Context
+  {
+      private bool $enable = false;
+      private string $filepath;
+  
+      public function initializeConfig(bool $enable, string $filepath)
+      {
+          $this->enable = $enable;
+          $this->filepath = $filepath;
+      }
+  
+      /** @BeforeScenario */
+      public function before(BeforeScenarioScope $scope)
+      {
+          if ($this->enable === false) {
+              return;
+          }
+
+          file_put_contents(
+              $this->filepath,
+              'START: ' . $scope->getScenario()->getTitle() . ' - ' . time() . PHP_EOL,
+              FILE_APPEND
+          );
+      }
+  
+      /** @AfterScenario */
+      public function after(AfterScenarioScope $scope)
+      {
+          if ($this->enable === false) {
+              return;
+          }
+  
+          file_put_contents(
+              $this->filepath,
+              'END: ' . $scope->getScenario()->getTitle() . ' - ' . time() . PHP_EOL,
+              FILE_APPEND
+          );
+      }
+  }
+
+Conclusion
+----------
+
+Congratulations! You have just created a simple Behat extension that logs scenario durations. This extension demonstrates the three essential steps to building a Behat extension: defining an extension, creating an initializer, and configuring contexts.
+
+Feel free to experiment with this extension and expand its functionality. For further learning, check out the `Behat hooks documentation <https://behat.org/en/latest/user_guide/context/hooks.html>`_ and explore existing extensions on `GitHub <https://github.com/search?o=desc&q=behat+extension+in%3Aname%2Cdescription+language%3APHP&ref=searchresults&s=stars&type=Repositories>`_.
+
+Happy testing!

--- a/cookbooks/creating_a_behat_extension.rst
+++ b/cookbooks/creating_a_behat_extension.rst
@@ -186,6 +186,12 @@ The code for ``LogsInitializer.php``:
   
       public function initializeContext(Context $context)
       {
+          /* 
+           * At the start of every scenario, behat will create a new instance of every `Context`
+           * registered in your project. It will then call this method with each new `Context` in
+           * turn. If you want to initialise multiple contexts, you can of course give them an 
+           * interface and check for that here.
+           */
           if (!$context instanceof LogsContext) {
               return;
           }

--- a/cookbooks/creating_a_behat_extension.rst
+++ b/cookbooks/creating_a_behat_extension.rst
@@ -15,7 +15,7 @@ Setting Up the Context
 First, we need to create a class that will handle the logging. There are several ways to do this (you can hook
 directly into behat's event dispatcher, for example).
 
-For our case, we will create a `Context` and use the :doc:`normal tagged hooks</user_guide/context/hooks>`
+For our case, we will create a ``Context`` and use the :doc:`normal tagged hooks</user_guide/context/hooks>`
 that you might have used in your own contexts.
 
 This is a straightforward approach, and means we can also show how to initialise any context with custom
@@ -90,12 +90,12 @@ Directory structure:
       ServiceContainer/
           LogsExtension.php   # This is where we'll define our extension
 
-To ensure Behat can find and load the ``LogsExtension.php`` file, it is important to place it within the `ServiceContainer` folder.
+To ensure Behat can find and load the ``LogsExtension.php`` file, it is important to place it within the ``ServiceContainer`` folder.
 While there might be alternatives, we will stick to the straightforward method.
 
 The ``getConfigKey`` method is used to identify our extension in the configuration, and the ``configure`` method is used to define the configuration tree.
 
-The code for `LogsExtension.php`:
+The code for ``LogsExtension.php``:
 
 .. code-block:: php
   
@@ -164,7 +164,8 @@ Directory structure:
 
 The code for ``LogsInitializer.php``:
 
-.. code-block:: php  
+.. code-block:: php
+
   <?php
 
   namespace Behat\LogsExtension\Context\Initializer;
@@ -203,6 +204,7 @@ The code for ``LogsInitializer.php``:
 We need to register the initializer definition within the Behat container through the ``LogsExtension``, ensuring it gets loaded:
 
 .. code-block:: php
+
   <?php
 
   // ...

--- a/cookbooks/creating_a_behat_extension.rst
+++ b/cookbooks/creating_a_behat_extension.rst
@@ -278,6 +278,6 @@ Conclusion
 
 Congratulations! You have just created a simple Behat extension that logs scenario durations. This extension demonstrates the three essential steps to building a Behat extension: defining an extension, creating an initializer, and configuring contexts.
 
-Feel free to experiment with this extension and expand its functionality. For further learning, check out the `Behat hooks documentation <https://behat.org/en/latest/user_guide/context/hooks.html>`_ and explore existing extensions on `GitHub <https://github.com/search?o=desc&q=behat+extension+in%3Aname%2Cdescription+language%3APHP&ref=searchresults&s=stars&type=Repositories>`_.
+Feel free to experiment with this extension and expand its functionality. For further learning, check out the :doc:`Behat hooks documentation</user_guide/context/hooks>` and explore existing extensions on `GitHub <https://github.com/search?o=desc&q=behat+extension+in%3Aname%2Cdescription+language%3APHP&ref=searchresults&s=stars&type=Repositories>`_.
 
 Happy testing!

--- a/cookbooks/creating_a_behat_extension.rst
+++ b/cookbooks/creating_a_behat_extension.rst
@@ -8,6 +8,7 @@ In this cookbook, we will create a simple extension named ``LogsExtension`` that
 #. Setting up the context
 #. Creating the extension
 #. Initializing the context
+#. Using the extension
 
 Setting Up the Context
 ----------------------
@@ -274,6 +275,32 @@ To complete the extension, we must add methods to ``LogsContext`` to receive the
           );
       }
   }
+
+Using the extension
+-------------------
+
+Now that the extension is ready and will inject values into context, we just need to configure it into a project.
+
+In the ``extensions`` key of a profile (``default`` in our case), we'll add the ``LogsExtension`` key and configure our ``filepath`` and ``enable`` value.
+
+Finally, we need to load the ``LogsExtension\Context\LogsContext`` into our suite.
+As the steps are hooked onto scenarios events, the context will be automatically called everytime a scenario starts or ends.
+
+Here's the ``behat.yaml``:
+
+.. code-block:: yaml
+
+  default:
+    suites:
+      default:
+        contexts:
+          - FeatureContext
+          - LogsExtension\Context\LogsContext
+    extensions:
+      LogsExtension:
+        filepath: 'logs.txt'
+        enable: true
+
 
 Conclusion
 ----------

--- a/cookbooks/creating_a_behat_extension.rst
+++ b/cookbooks/creating_a_behat_extension.rst
@@ -12,7 +12,14 @@ In this cookbook, we will create a simple extension named ``LogsExtension`` that
 Setting Up the Context
 ----------------------
 
-First, we need to create a context that will handle the logging.
+First, we need to create a class that will handle the logging. There are several ways to do this (you can hook
+directly into behat's event dispatcher, for example).
+
+For our case, we will create a `Context` and use the :doc:`normal tagged hooks</user_guide/context/hooks>`
+that you might have used in your own contexts.
+
+This is a straightforward approach, and means we can also show how to initialise any context with custom
+configuration or dependencies.
 The ``LogsExtension`` will provide a ``LogsContext`` that hooks into scenarios to log their start and end times.
 
 Directory structure:

--- a/cookbooks/creating_a_context_configuration_extension.rst
+++ b/cookbooks/creating_a_context_configuration_extension.rst
@@ -1,4 +1,4 @@
-Creating a Behat extension
+Creating a Behat extension to provide custom configuration for Contexts
 ==========================
 
 Extensions are particularly useful when configuration becomes a necessity.
@@ -13,15 +13,14 @@ In this cookbook, we will create a simple extension named ``HelloWorld`` that wi
 Setting Up the Context
 ----------------------
 
-First, we need to create a ``Context`` class that will throw a ``PendingException`` with a configurable text.
-A behavior that could be enable or not.
+First, we create a ``Context`` class that will throw a ``PendingException`` with a configurable text.
+The configuration will also control whether the behaviour is enabled or not.
 
 .. code-block::
 
   src/
       Context/
           HelloWorldContext.php   # This is where we'll implement our step
-
 
 .. code-block:: php
 
@@ -37,6 +36,9 @@ A behavior that could be enable or not.
       private bool $enable = false;
       private string $text;
 
+      /*
+       * Will be used by the extension to initialise the context with configuration values.
+       */
       public function initializeConfig(bool $enable, string $text)
       {
           $this->enable = $enable;
@@ -205,34 +207,6 @@ We need to register the initializer definition within the Behat container throug
       // ...
   }
 
-To complete the extension, we must add methods to ``HelloWorldContext`` to receive the configuration values and use those in the hooks:
-
-.. code-block:: php
-
-  // ...
-
-  class HelloWorldContext implements Context
-  {
-      private bool $enable = false;
-      private string $text;
-
-      public function initializeConfig(bool $enable, string $text)
-      {
-          $this->enable = $enable;
-          $this->text = $text;
-      }
-
-      /** @Given I say Hello World */
-      public function helloWorld()
-      {
-          if ($this->enable === false) {
-              return;
-          }
-  
-          throw new PendingException($this->text);
-      }
-  }
-
 Using the extension
 -------------------
 
@@ -260,18 +234,19 @@ Here's the ``behat.yaml``:
 And now a scenario like this one:
 
 .. code-block::
+
   Feature: Test
-  
+
     Scenario: Test
       Given I say Hello World
 
-Will display our text as a pending text.
+Will display our text ``Hi there!`` as a pending exception.
 
 Conclusion
 ----------
 
 Congratulations! You have just created a simple Behat extension.
-This extension demonstrates the three essential steps to building a Behat extension: defining an extension, creating an initializer, and configuring contexts.
+This extension demonstrates three of the common steps to building a Behat extension: defining an extension, creating an initializer, and configuring contexts.
 
 Feel free to experiment with this extension and expand its functionality.
 


### PR DESCRIPTION
I recently wrote a blog post explaining how to create a Behat extension: [How to Create a Behat Extension](https://monitaurus.github.io/posts/how-to-create-a-behat-extension.html).

As there's not so much information about extensions in the official Behat's documentation, I submit this PR to add a cookbook, which is a rewrite of the post, in the Behat docs tone and removing extra stuff.

It's a cookbook and not a documentation, as it's doesn't explain the whole extension system, but give information on creating a simple extension.