### PR TITLE
chore: reorder information about multiline arguments

### DIFF
--- a/user_guide/writing_scenarios.rst
+++ b/user_guide/writing_scenarios.rst
@@ -280,6 +280,19 @@ The scenario that is actually run is:
       # <left> replaced with 7:
       Then I should have 7 cucumbers
 
+Multiline Arguments
+-------------------
+
+The one line `steps`_ let Behat extract small strings from your steps
+and receive them in your step definitions. However, there are times when you
+want to pass a richer data structure from a step to a step definition.
+
+This is what multiline step arguments are designed for. They are written on
+lines immediately following a step and are passed to the step definition
+method as the last argument.
+
+Multiline step arguments come in two flavours: `tables`_ or `pystrings`_.
+
 Tables
 ------
 
@@ -325,19 +338,6 @@ usually as input to a ``Given`` or as expected output from a ``Then``:
     A table is injected into a definition as a ``TableNode`` object, from
     which you can get hash by columns (``TableNode::getHash()`` method) or by
     rows (``TableNode::getRowsHash()``).
-
-Multiline Arguments
--------------------
-
-The one line `steps`_ let Behat extract small strings from your steps
-and receive them in your step definitions. However, there are times when you
-want to pass a richer data structure from a step to a step definition.
-
-This is what multiline step arguments are designed for. They are written on
-lines immediately following a step and are passed to the step definition
-method as the last argument.
-
-Multiline step arguments come in two flavours: `tables`_ or `pystrings`_.
 
 Pystrings
 ---------


### PR DESCRIPTION
In the current docs first it talks about tables, then it explains about multiline arguments (which include tables) and then talks about pystrings. It makes sense to reorder this information so that it first introduces multiline arguments, then talks about tables and finally about pystrings. This PR just performs this re-ordering