### PR TITLE
chore: add a Dockerfile to facilitate running the build process using docker

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    # Note: Update the instructions for building locally in README.md if the python version changes
+    # Note: Update the Dockerfile if the python version changes
     python: "3.12"
 
 # Build documentation in the "docs/" directory with Sphinx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12
+
+WORKDIR /workspace
+
+COPY requirements.txt .
+RUN python -m pip install --upgrade --no-cache-dir pip setuptools
+RUN python -m pip install --upgrade --no-cache-dir -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -39,18 +39,14 @@ built version.
 ## Building locally
 
 For more significant changes, you may want to build the full docs site locally. For this, you will need python, sphinx
-and the relevant dependencies. The easiest solution may be to use a temporary docker container.
+and the relevant dependencies. The easiest solution may be to use a temporary docker container. In this repository you will
+find a `Dockerfile` and a `docker-compose.yml` file that will let you do that easily
 
 ```bash
-# Launch an interactive shell in a container with the required python version
-docker run --rm -it --entrypoint bash -v $PWD:/workspace -w /workspace python:3.12.3
+# Launch a docker container with the right dependencies and run the site build command
+# This will build the container if needed, using the Dockerfile
+docker compose run --rm read-the-docs-builder
 
-# In your container, install the required dependencies:
-python -m pip install --upgrade --no-cache-dir pip setuptools
-python -m pip install --upgrade --no-cache-dir -r requirements.txt
-
-# Then, to build the docs:
-python -m sphinx -T -W --keep-going -b html -d _build/doctrees -D language=en . _build/html
 # The docs will be generated into _build/html
 # Check the CLI ouput for any errors
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+    read-the-docs-builder:
+        build:
+            context: .
+        volumes:
+            - ./:/workspace
+        command: python -m sphinx -T -W --keep-going -b html -d _build/doctrees -D language=en . _build/html


### PR DESCRIPTION
The instructions to run the build command locally asked you to start a python docker container, then add the dependencies and finally run the build command. To make the process easier I created a `Dockerfile` and a `docker-compose.yml` file that allow you to use docker compose to easily build the container with the needed dependencies and run the build command