### PR TITLE
chore: save site as an artifact to ease testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,3 +21,9 @@ jobs:
 
       - name: Check build
         run: cat _build/html/guides.html
+
+      - name: save site as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs
+          path: _build/html


### PR DESCRIPTION
Saves the doc site generated in the Github Actions test as an artifact. This makes it easier for anyone to see the changes in the site without having to build the site themselves

See the associated job run for this PR for an example artifact:
https://github.com/Behat/docs/actions/runs/11743206188/job/32715512328