### PR TITLE
chore: Fix syntax in custom psr-4 autoloading example

### DIFF
--- a/user_guide/configuration.rst
+++ b/user_guide/configuration.rst
@@ -223,16 +223,16 @@ You can also use ``composer.json`` to autoload, which will also allow for ``PSR-
 
 .. code-block:: json
 
-    // composer.json
-    
-    "autoload-dev": {
+    {
+      "autoload-dev": {
         "psr-4": {
-           "My\\Application\\Namespace\\Bootstrap\\": "app/features/bootstrap"
+          "My\\Application\\Namespace\\Bootstrap\\": "app/features/bootstrap"
         }
+      }
     }
 
 If you add this to your ``composer.json`` file, then you won't need to specify autoloading in
-your ``behat.yml` file:
+your ``behat.yml`` file:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
Sorry, I was rushing to clear my easy notifications and didn't notice that the checks hadn't run on #123 so it broke the build on merge.