### PR TITLE
docs: remove prefix and short summary docs

### DIFF
--- a/user_guide/command_line_tool/formatting.rst
+++ b/user_guide/command_line_tool/formatting.rst
@@ -116,6 +116,8 @@ The following options are specific to the Pretty formatter:
 * ``multiline`` print out PyStrings and TableNodes in full. Boolean, defaults to true.
 * ``showOutput`` show the test stdout output as part of the formatter output. Should be one of the
   ``ShowOutputOption`` enum values, defaults to ``ShowOutputOption::Yes``.
+* ``shortSummary`` show a short summary (with just a list of scenarios) or a long summary (with a list of steps).
+  Defaults to true (short summary)
 
 Progress formatter
 ^^^^^^^^^^^^^^^^^^
@@ -125,6 +127,8 @@ The following options are specific to the Progress formatter:
 * ``timer`` show time and memory usage at the end of the test run. Boolean, defaults to true.
 * ``showOutput`` show the test stdout output as part of the formatter output. Should be one of the
   ``ShowOutputOption`` enum values, defaults to ``ShowOutputOption::InSummary``.
+* ``shortSummary`` show a short summary (with just a list of scenarios) or a long summary (with a list of steps).
+  Defaults to false (long summary)
 
 Setting format options
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/user_guide/command_line_tool/formatting.rst
+++ b/user_guide/command_line_tool/formatting.rst
@@ -116,8 +116,8 @@ The following options are specific to the Pretty formatter:
 * ``multiline`` print out PyStrings and TableNodes in full. Boolean, defaults to true.
 * ``showOutput`` show the test stdout output as part of the formatter output. Should be one of the
   ``ShowOutputOption`` enum values, defaults to ``ShowOutputOption::Yes``.
-* ``shortSummary`` show a short summary (with just a list of scenarios) or a long summary (with a list of steps).
-  Defaults to true (short summary)
+* ``shortSummary`` show just a list of failing scenarios at the end of the output. If false, a full summary
+  (which also includes a list of failing steps) will be printed. Defaults to true
 
 Progress formatter
 ^^^^^^^^^^^^^^^^^^
@@ -127,8 +127,8 @@ The following options are specific to the Progress formatter:
 * ``timer`` show time and memory usage at the end of the test run. Boolean, defaults to true.
 * ``showOutput`` show the test stdout output as part of the formatter output. Should be one of the
   ``ShowOutputOption`` enum values, defaults to ``ShowOutputOption::InSummary``.
-* ``shortSummary`` show a short summary (with just a list of scenarios) or a long summary (with a list of steps).
-  Defaults to false (long summary)
+* ``shortSummary`` show just a list of failing scenarios at the end of the output. If false, a full summary
+  (which also includes a list of failing steps) will be printed. Defaults to false
 
 Setting format options
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/user_guide/configuration/printing_paths.rst
+++ b/user_guide/configuration/printing_paths.rst
@@ -21,6 +21,12 @@ need to be different if you are running your code within a Docker container). So
 - For PhpStorm: ``phpstorm://open?file={relPath}&line={line}``
 - For VS Code: ``vscode://file/{absPath}:{line}``
 
+``Remove Prefix``: This allows you to define a list of prefixes that need to be removed from paths
+when printing them. This affects only the visible paths, not the ones used in the editorUrl. This is
+useful if your feature or context files are located in some subfolders, for example ``tests/behat/features``
+and ``src/behat``. It is not very informative if these folders are always printed when printing paths
+and you may prefer to remove them
+
 .. note::
 
     The path style can be different for the visible path and the one used in the editor URL. For example you
@@ -40,11 +46,15 @@ These options can be set using the ``withPathOptions()`` function of the ``Profi
         ->withProfile((new Profile('default'))
             ->withPathOptions(
                 printAbsolutePaths: true,
-                editorUrl: 'phpstorm://open?file={relPath}&line={line}'
+                editorUrl: 'phpstorm://open?file={relPath}&line={line}',
+                removePrefix: [
+                    'tests/behat/features',
+                    'src/behat',
+                ]
             ));
 
 They can also be set as command line options (notice that the editor URL will usually need to be quoted):
 
 .. code-block:: bash
 
-    behat --print-absolute-paths --editor-url="phpstorm://open?file={relPath}&line={line}"
+    behat --print-absolute-paths --editor-url="phpstorm://open?file={relPath}&line={line}" --remove-prefix=tests/behat/features,src/behat


### PR DESCRIPTION
Adds documentation for the new `removePrefix` path configuration and the new `shortSummary` formatter option