### PR TITLE
Fixed incorrect "OR" tag specified for tagged hooks

### DIFF
--- a/user_guide/context/hooks.rst
+++ b/user_guide/context/hooks.rst
@@ -267,7 +267,9 @@ Tagged Hooks
 Sometimes you may want a certain hook to run only for certain scenarios,
 features or steps. This can be achieved by associating a ``BeforeFeature``,
 ``AfterFeature``, ``BeforeScenario`` or ``AfterScenario`` hook with one
-or more tags. You can also use ``OR`` (``||``) and ``AND`` (``&&``) tags:
+or more tags. You can also use ``OR`` (``,``) and ``AND`` (``&&``) tags:
+
+Use the ``,`` tag to execute a hook when it has *any* of the provided tags:
 
 .. code-block:: php
 


### PR DESCRIPTION
Documentation previously incorrectly stated that the "OR" tag to be used for tagged hooks was `||`. The "OR" tag is actually `,`. I updated the documentation to reflect this and added a sentence regarding its use to be consistent with the "AND" tag example.

Closes behat/behat#1850