### PR TITLE
docs: Document the DataTable and DocString step argument types

### DIFF
--- a/user_guide/writing_scenarios.rst
+++ b/user_guide/writing_scenarios.rst
@@ -321,22 +321,35 @@ usually as input to a ``Given`` or as expected output from a ``Then``:
 
     .. code-block:: php
 
-        use Behat\Gherkin\Node\TableNode;
+        use Behat\Step\DataTable;
         use Behat\Step\Given;
 
         // ...
 
         #[Given('the following people exist:')]
-        public function thePeopleExist(TableNode $table)
+        public function thePeopleExist(DataTable $table)
         {
-            foreach ($table as $row) {
+            foreach ($table->asMaps() as $row) {
                 // $row['name'], $row['email'], $row['phone']
             }
         }
 
-    A table is injected into a definition as a ``TableNode`` object, from
-    which you can get hash by columns (``TableNode::getHash()`` method) or by
-    rows (``TableNode::getRowsHash()``).
+    Type the parameter as ``DataTable`` and Behat passes the table as such.
+    It reads the table in whichever shape the step needs:
+
+    * ``asMaps()`` uses the first row as keys, giving one associative array
+      per following row, which is what the example above iterates over;
+    * ``asLists()`` returns every row as a plain list of cells, header row
+      included, for a table with no header;
+    * ``asMap()`` turns a two-column table into a single associative array,
+      which suits a table of settings or of expected values;
+    * ``cell()``, ``row()``, ``column()``, ``height()``, ``width()``,
+      ``isEmpty()`` and ``transpose()`` cover the rest.
+
+    ``DataTable`` was added in Behat 3.33. Typing the parameter as
+    ``Behat\Gherkin\Node\TableNode`` still works and is not deprecated, but
+    ``DataTable`` keeps your definitions decoupled from the Gherkin syntax
+    tree.
 
 Pystrings
 ^^^^^^^^^
@@ -371,20 +384,24 @@ three double-quote marks (``"""``), placed on their own line:
 
     .. code-block:: php
 
-        use Behat\Gherkin\Node\PyStringNode;
+        use Behat\Step\DocString;
         use Behat\Step\Given;
 
         // ...
 
         #[Given('a blog post named :title with:')]
-        public function blogPost($title, PyStringNode $markdown)
+        public function blogPost($title, DocString $markdown)
         {
-            $this->createPost($title, $markdown->getRaw());
+            $this->createPost($title, $markdown->getContent());
         }
 
-    PyStrings are stored in a ``PyStringNode`` instance, which you can simply
-    convert to a string with ``(string) $pystring`` or ``$pystring->getRaw()``
-    as in the example above.
+    Type the parameter as ``DocString`` to receive the text. Read it with
+    ``getContent()``, or cast it with ``(string) $markdown``.
+
+    ``DocString`` was added in Behat 3.33. Typing the parameter as
+    ``Behat\Gherkin\Node\PyStringNode`` still works and is not deprecated,
+    but ``DocString`` keeps your definitions decoupled from the Gherkin syntax
+    tree.
 
 .. note::
 


### PR DESCRIPTION
Documents the `DataTable` and `DocString` step argument types added in Behat/Behat#1864, which @acoulton asked for as a follow-up.

The two sidebars of "Multiline step arguments" now show the new types, since they are what a reader should reach for:

```diff
-use Behat\Gherkin\Node\TableNode;
+use Behat\Step\DataTable;

 #[Given('the following people exist:')]
-public function thePeopleExist(TableNode $table)
+public function thePeopleExist(DataTable $table)
 {
-    foreach ($table as $row) {
+    foreach ($table->asMaps() as $row) {
```

For tables the accessors are worth listing, because which one to use depends on the shape of the table and that is not obvious from the type name: `asMaps()` for a table with a header row, `asLists()` for one without, `asMap()` for the two-column case, then `cell()`, `row()`, `column()`, `height()`, `width()`, `isEmpty()` and `transpose()`.

Both sidebars say plainly that `TableNode` and `PyStringNode` still work and are not deprecated, so nobody reads this as a migration they have to do.

Two things I checked rather than assumed: the version is 3.33, since 3.32.0 is the latest release and the feature is merged on `3.x`; and I dropped two `:ref:` links I had first written to a `TableNode` and a `PyStringNode` section, because no such anchors exist and they would have broken the build. The class names are written out instead.

Built locally with `docker compose run --rm read-the-docs-builder build`: build succeeded, and the rendered page carries the new sections.

The snippet generation half of the follow-up is Behat/Behat#1878.
